### PR TITLE
Adapted 1.18

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -10,7 +10,5 @@ plugins {
 }
 
 paperShelled {
-    paperShelledVersion = 'ba69b5ac29'
-    annotationsVersion = '7861eb372c'
-    jarUrl = 'https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/257/downloads/paper-1.17.1-257.jar'
+    jarUrl = 'https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/175/downloads/paper-1.18.1-175.jar'
 }

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object BuildPluginsVersion {
-    const val KOTLIN = "1.5.21"
-    const val PLUGIN_PUBLISH = "0.14.0"
+    const val KOTLIN = "1.6.10"//1.5.29
+    const val PLUGIN_PUBLISH = "0.15.0"
     const val VERSIONS_PLUGIN = "0.38.0"
 }

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object BuildPluginsVersion {
     const val KOTLIN = "1.6.10"//1.5.29
     const val PLUGIN_PUBLISH = "0.15.0"
-    const val VERSIONS_PLUGIN = "0.38.0"
+    const val VERSIONS_PLUGIN = "0.39.0"
 }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -20,8 +20,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 gradlePlugin {

--- a/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Extension.kt
+++ b/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Extension.kt
@@ -2,8 +2,10 @@ package cn.apisium.papershelled.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import java.io.File
 import java.nio.file.Files
 import javax.inject.Inject
 
@@ -16,6 +18,7 @@ abstract class Extension @Inject constructor(private val project: Project) {
     val jarFile: RegularFileProperty = objects.fileProperty().convention(project.layout.getCache("server.jar"))
     val reobfFile: RegularFileProperty = objects.fileProperty().convention(project.layout.getCache("reobf.tiny"))
     val paperShelledJar: RegularFileProperty = objects.fileProperty().convention(project.layout.getCache("out.jar"))
+    val paperShelledLib: RegularFileProperty = objects.fileProperty().convention(project.layout.getCache("libs"))
     val relocateCraftBukkit: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
     val reobfAfterJarTask: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
     val generateReferenceMap: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
@@ -34,4 +37,5 @@ abstract class Extension @Inject constructor(private val project: Project) {
 
     @Suppress("unused")
     fun jar(): ConfigurableFileCollection = project.files(paperShelledJar.get().asFile)
+    fun lib(): ConfigurableFileTree = project.fileTree(paperShelledLib.get().asFile)
 }

--- a/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Plugin.kt
+++ b/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Plugin.kt
@@ -4,6 +4,7 @@ package cn.apisium.papershelled.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import java.net.URI
@@ -27,6 +28,7 @@ abstract class Plugin : Plugin<Project> {
             it.jarFile.set(extension.jarFile)
             it.reobfFile.set(extension.reobfFile)
             it.paperShelledJar.set(extension.paperShelledJar)
+            it.paperShelledLib.set(extension.paperShelledLib)
             if (!Files.exists(it.jarFile.get().asFile.toPath())) it.dependsOn(download)
         }
 
@@ -98,7 +100,10 @@ abstract class Plugin : Plugin<Project> {
                 }
                 dep.add("compileOnly", dep.create("org.spongepowered:mixin:$mv"))
             }
-            if (extension.addJarToDependencies.get()) dep.add("compileOnly", dep.create(extension.jar()))
+            if (extension.addJarToDependencies.get()) {
+                dep.add("compileOnly", dep.create(extension.jar()))
+                dep.add("compileOnly", dep.create(extension.lib()))
+            }
         }
     }
 }

--- a/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Tasks.kt
+++ b/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Tasks.kt
@@ -12,14 +12,17 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.workers.WorkerExecutor
+import java.io.IOException
+import java.lang.Exception
+import java.lang.reflect.AccessibleObject
+import java.net.URL
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.inject.Inject
-import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.name
+import kotlin.io.path.*
 
 private const val GROUP = "papershelled"
 
@@ -78,12 +81,114 @@ abstract class GenerateMappedJarTask : DefaultTask() {
     @get:Optional
     abstract val paperShelledJar: RegularFileProperty
 
+    @get:Input
+    @get:Option(option = "paperShelledLib", description = "The directory of the libraries released by paper")
+    @get:Optional
+    abstract val paperShelledLib: RegularFileProperty
+
     @ExperimentalPathApi
     @TaskAction
     fun run() {
         Files.createDirectories(project.layout.tmp)
         Files.createDirectories(project.layout.cache)
         val reobf = reobfFile.get().asFile.toPath()
+        try {
+            val path = URLClassLoader(arrayOf(jarFile.get().asFile.toURI().toURL())).use {
+                val clipClazz = it.loadClass("io.papermc.paperclip.Paperclip")
+                val ctxClazz = it.loadClass("io.papermc.paperclip.DownloadContext")
+                val repoDir = Path.of(System.getProperty("bundlerRepoDir", ""))
+                val patches = clipClazz.getDeclaredMethod("findPatches").run {
+                    isAccessible = true
+                    invoke(null) as Array<*>
+                }
+                val downloadContext = clipClazz.getDeclaredMethod("findDownloadContext").run {
+                    isAccessible = true
+                    invoke(null)
+                }
+                require(!(patches.isNotEmpty() && downloadContext == null)) {
+                    "patches.list file found without a corresponding original-url file"
+                }
+                val baseFile = if (downloadContext != null) {
+                    try {
+                        downloadContext::class.java.getDeclaredMethod("download", Path::class.java)
+                            .apply { isAccessible = true }.invoke(downloadContext, repoDir)
+                    } catch (e: IOException) {
+                        throw Exception("Failed to download original jar", e)
+                    }
+                    downloadContext::class.java.getDeclaredMethod("getOutputFile", Path::class.java)
+                        .apply { isAccessible = true }.invoke(downloadContext, repoDir) as Path
+                } else {
+                    null
+                }
+                clipClazz.declaredMethods.filter { it.name == "extractAndApplyPatches" }[0].run {
+                    isAccessible = true
+                    invoke(null, baseFile, patches, repoDir) as Map<String, Map<String, URL>>
+                }
+            }
+            val paperDict = path["versions"];
+            require(paperDict != null) {
+                "Server jar output directory was not found."
+            }
+            val paperJar = paperDict.values.elementAt(0).toURI().toPath()
+            if (Files.exists(reobf)) Files.delete(reobf)
+            val obcVersion = FileSystems.newFileSystem(paperJar, null as ClassLoader?).use { fs ->
+                val data =
+                    Files.readAllBytes(fs.getPath("/META-INF/mappings/reobf.tiny")).toString(StandardCharsets.UTF_8)
+                Files.write(
+                    reobf, data.replaceFirst(LEFT[1], LEFT[0]).replaceFirst(RIGHT[1], RIGHT[0])
+                        .toByteArray(StandardCharsets.UTF_8)
+                )
+                Files.list(fs.getPath("/org/bukkit/craftbukkit"))
+                    .map { it.fileName.name }
+                    .filter { it.startsWith("v") }
+                    .findFirst().get()
+            }
+            logger.lifecycle("Found org.bukkit.craftbukkit: $obcVersion")
+            Files.write(
+                project.layout.cache.resolve("mappingVersion.txt"),
+                obcVersion.toByteArray(StandardCharsets.UTF_8)
+            )
+            val temp = project.layout.tmp.resolve("temp.jar")
+            val remapper = TinyRemapper.newRemapper()
+                .withMappings(TinyUtils.createTinyMappingProvider(reobf as Path, RIGHT[0], LEFT[0]))
+                .ignoreConflicts(true)
+                .fixPackageAccess(true)
+                .rebuildSourceFilenames(true)
+                .renameInvalidLocals(true)
+                .threads(-1)
+                .build()
+            try {
+                OutputConsumerPath.Builder(temp).build().use {
+                    it.addNonClassFiles(paperJar, NonClassCopyMode.FIX_META_INF, remapper)
+                    remapper.readInputs(paperJar)
+                    remapper.apply(it)
+                }
+            } finally {
+                remapper.finish()
+            }
+            JarRelocator(
+                temp.toFile(), paperShelledJar.get().asFile, listOf(
+                    Relocation("org.bukkit.craftbukkit.$obcVersion", "org.bukkit.craftbukkit")
+                )
+            ).run()
+            temp.deleteExisting()
+            //others, come up to our output folder!
+            val allOther = path["libraries"]
+            require(allOther != null) {
+                "No libraries folder is found"
+            }
+            val libFolder = paperShelledLib.get().asFile.toPath()
+            if (!libFolder.exists()) {
+                libFolder.createDirectories()
+            }
+            allOther.values.map { it.toURI().toPath() }.forEach {
+                it.copyTo(libFolder.resolve(it.fileName))
+            }
+        } catch (unused: UnsupportedClassVersionError) { legacy(reobf)
+        } catch (it: NoSuchMethodException) { it.printStackTrace();legacy(reobf) }
+    }
+
+    private fun legacy(reobf: Path) {
         val path = URLClassLoader(arrayOf(jarFile.get().asFile.toURI().toURL())).use {
             val m = it.loadClass("io.papermc.paperclip.Paperclip").getDeclaredMethod("setupEnv")
             m.isAccessible = true
@@ -103,7 +208,7 @@ abstract class GenerateMappedJarTask : DefaultTask() {
         Files.write(project.layout.cache.resolve("mappingVersion.txt"), obcVersion.toByteArray(StandardCharsets.UTF_8))
         val temp = project.layout.tmp.resolve("temp.jar")
         val remapper = TinyRemapper.newRemapper()
-            .withMappings(TinyUtils.createTinyMappingProvider(reobf as Path, RIGHT[0], LEFT[0]))
+            .withMappings(TinyUtils.createTinyMappingProvider(reobf, RIGHT[0], LEFT[0]))
             .ignoreConflicts(true)
             .fixPackageAccess(true)
             .rebuildSourceFilenames(true)

--- a/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Utils.kt
+++ b/plugin-build/plugin/src/main/java/cn/apisium/papershelled/gradle/Utils.kt
@@ -42,7 +42,6 @@ abstract class DownloadService : BuildService<BuildServiceParameters.None>, Auto
         builder.build()
     }
 
-    @ExperimentalPathApi
     fun download(source: URL, target: Path) {
         target.parent.createDirectories()
 
@@ -88,7 +87,6 @@ abstract class DownloadService : BuildService<BuildServiceParameters.None>, Auto
         }
     }
 
-    @ExperimentalPathApi
     private fun handleResponse(response: CloseableHttpResponse, target: Path): Instant {
         val lastModified = with(response.getLastHeader("Last-Modified")) {
             if (this == null) {
@@ -113,7 +111,6 @@ abstract class DownloadService : BuildService<BuildServiceParameters.None>, Auto
         return lastModified
     }
 
-    @ExperimentalPathApi
     private fun saveEtag(response: CloseableHttpResponse, lastModified: Instant, target: Path, etagFile: Path) {
         if (lastModified != Instant.EPOCH) {
             target.setLastModifiedTime(FileTime.from(lastModified))
@@ -137,7 +134,6 @@ interface DownloadParams : WorkParameters {
 }
 
 abstract class DownloadWorker : WorkAction<DownloadParams> {
-    @ExperimentalPathApi
     override fun execute() {
         parameters.downloader.get().download(URI.create(parameters.source.get()).toURL(),
             parameters.target.get().asFile.toPath())


### PR DESCRIPTION
## 🚀 Description
Adapted new PaperClip for java17;

## 📄 Motivation and Context
PaperClip has been updated and most of its structure is changed, breaking the construction mechanism.
Here I added the support for new PaperClip, keeping the old one.

## 🧪 How Has This Been Tested?
Tested with the example project. I also compiled my plugin and it worked as intended.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.